### PR TITLE
feat: add feature request template for GitHub issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/prompts/.commit_convention.md
+++ b/.github/prompts/.commit_convention.md
@@ -1,0 +1,73 @@
+Write a commit message in english regarding the following commit convention.
+
+Git Commit Convention
+=====================
+
+Format of the commit message
+----------------------------
+
+    <type>: <subject>
+    <NEWLINE>
+    <body>
+    <NEWLINE>
+    <footer>
+
+``<type>`` is:
+
+ - feat (feature)
+ - fix (bug fix)
+ - doc (documentation)
+ - style (formatting, missing semicolons, ...)
+ - refactor
+ - test (when adding missing tests)
+ - chore (maintain, ex: travis-ci)
+ - perf (performance improvement, optimization, ...)
+
+Every `feat` or `fix` commit must have a `changelog-*` label, and a commit message
+beginning with "This PR " that will be included in the changelog.
+
+``<subject>`` has the following constraints:
+
+ - use imperative, present tense: "change" not "changed" nor "changes"
+ - do not capitalize the first letter
+ - no dot(.) at the end
+
+``<body>`` has the following constraints:
+
+ - just as in ``<subject>``, use imperative, present tense
+ - includes motivation for the change and contrasts with previous
+   behavior
+ - If a `changelog-*` label is present, the body must begin with "This PR ".
+
+``<footer>`` is optional and may contain two items:
+
+ - Breaking changes: All breaking changes have to be mentioned in
+   footer with the description of the change, justification and
+   migration notes
+ - Referencing issues: Closed bugs should be listed on a separate line
+   in the footer prefixed with "Closes" keyword like this:
+
+    Closes #123, #456
+
+Examples
+--------
+
+fix: add declarations for operator<<(std::ostream&, expr const&) and operator<<(std::ostream&, context const&) in the kernel
+
+This PR adds declarations `operator<<` for raw printing.
+The actual implementation of these two operators is outside of the
+kernel. They are implemented in the file 'library/printer.cpp'.
+
+We declare them in the kernel to prevent the following problem.
+Suppose there is a file 'foo.cpp' that does not include 'library/printer.h',
+but contains
+```cpp
+expr a;
+...
+std::cout << a << "\n";
+...
+```
+
+The compiler does not generate an error message. It silently uses the
+operator bool() to coerce the expression into a Boolean. This produces
+counter-intuitive behavior, and may confuse developers.

--- a/.github/prompts/.commit_convention.md
+++ b/.github/prompts/.commit_convention.md
@@ -1,4 +1,4 @@
-Write a commit message in english regarding the following commit convention.
+Write a commit message in English regarding the following commit convention.
 
 Git Commit Convention
 =====================


### PR DESCRIPTION
This PR introduces a markdown template for feature requests in the GitHub repository. The template guides users to provide clear descriptions of their feature ideas, including related problems, proposed solutions, and alternative considerations.