### PR TITLE
test: add tests for GraphModule serialization and deserialization

### DIFF
--- a/crates/fx-pybridge/build.rs
+++ b/crates/fx-pybridge/build.rs
@@ -1,0 +1,42 @@
+// crates/fx-pybridge/build.rs
+use std::env;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=PYO3_PYTHON");
+
+    if let Ok(python_interpreter_path) = env::var("PYO3_PYTHON") {
+        let get_site_packages_cmd = "import sysconfig; print(sysconfig.get_path('platlib'))";
+
+        match Command::new(&python_interpreter_path)
+            .arg("-c")
+            .arg(get_site_packages_cmd)
+            .output()
+        {
+            Ok(output) => {
+                if output.status.success() {
+                    let site_packages_path = String::from_utf8(output.stdout)
+                        .map(|s| s.trim().to_string())
+                        .unwrap_or_default();
+
+                    if !site_packages_path.is_empty() && PathBuf::from(&site_packages_path).exists() {
+                        println!("cargo:rustc-env=FX_PYBRIDGE_TEST_SITE_PACKAGES={}", site_packages_path);
+                        // For debugging purposes, uncomment the following lines to see the output:
+                        // eprintln!("build.rs: Set FX_PYBRIDGE_TEST_SITE_PACKAGES to {}", site_packages_path);
+                    } else {
+                        // eprintln!("build.rs: Failed to get valid site-packages path from Python. Output: '{}'", site_packages_path);
+                    }
+                } else {
+                    // let stderr = String::from_utf8_lossy(&output.stderr);
+                    // eprintln!("build.rs: Python script for site-packages failed. Stderr: {}", stderr);
+                }
+            }
+            Err(_e) => {
+                // eprintln!("build.rs: Failed to execute Python interpreter at {}: {}", python_interpreter_path, e);
+            }
+        }
+    } else {
+        // eprintln!("build.rs: PYO3_PYTHON environment variable is not set. Cannot determine site-packages for tests.");
+    }
+}

--- a/crates/fx-pybridge/src/lib.rs
+++ b/crates/fx-pybridge/src/lib.rs
@@ -1,0 +1,17 @@
+use pyo3::prelude::*;
+use torch_fx_rs::GraphModule;
+use pyo3::types::IntoPyDict;
+
+pub fn graphmodule_from_pickle(py: Python<'_>, path: &str) -> PyResult<Py<GraphModule>> {
+    let torch = py.import("torch")?;
+    let py_gm = torch.call_method("load", (path,), Some([("weights_only", false)].into_py_dict(py)))?;
+    let gm: Py<GraphModule> = py_gm.extract()?;
+    Ok(gm)
+}
+
+pub fn graphmodule_to_pickle(py: Python<'_>, gm: &GraphModule, path: &str) -> PyResult<()> {
+    let torch = py.import("torch")?;
+    let py_gm = gm.as_ref();
+    torch.call_method("save", (py_gm, path), None)?;
+    Ok(())
+}

--- a/crates/fx-pybridge/tests/graphmodule_pickle.rs
+++ b/crates/fx-pybridge/tests/graphmodule_pickle.rs
@@ -1,0 +1,114 @@
+use pyo3::PyResult;
+use pyo3::Python;
+use pyo3::types::{PyAny, PyTuple, PyModule};
+use fx_pybridge::{graphmodule_from_pickle, graphmodule_to_pickle};
+use std::fs;
+use std::process::Command;
+
+const ORIG_PICKLE: &str = "tests/data/test_module.pt";
+const ROUNDTRIP_PICKLE: &str = "tests/data/test_module_roundtrip.pt";
+const GEN_SCRIPT: &str = "tests/scripts/gen_fx_module.py";
+
+fn setup_test_data() {
+    let status = Command::new("python3")
+        .arg(GEN_SCRIPT)
+        .status()
+        .expect("Failed to run gen_fx_module.py");
+    assert!(status.success());
+}
+
+fn cleanup_test_data() {
+    let _ = fs::remove_file(ORIG_PICKLE);
+    let _ = fs::remove_file(ROUNDTRIP_PICKLE);
+}
+
+fn graphmodules_are_semantically_equal(py: Python, gm1: &PyAny, gm2: &PyAny) -> PyResult<bool> {
+    let code1 = gm1.getattr("code")?.extract::<String>()?;
+    let code2 = gm2.getattr("code")?.extract::<String>()?;
+
+    if code1 != code2 {
+        println!("Graph codes differ.");
+        // fs::write("tests/data/gm1_code.py", &code1).expect("Failed to write gm1_code.py");
+        // fs::write("tests/data/gm2_code.py", &code2).expect("Failed to write gm2_code.py");
+        // println!("--- Code for GM1:\n{}\n--- Code for GM2:\n{}", code1, code2);
+        return Ok(false);
+    }
+
+    let get_tabular_script = r#"
+import io
+import sys
+
+def get_tabular_string(graph_module_or_graph):
+    graph_to_print = getattr(graph_module_or_graph, 'graph', graph_module_or_graph)
+
+    old_stdout = sys.stdout
+    sys.stdout = captured_output = io.StringIO()
+    graph_to_print.print_tabular()
+    sys.stdout = old_stdout
+    return captured_output.getvalue()
+"#;
+    let py_get_tabular_func = PyModule::from_code(py, get_tabular_script, "", "")?
+        .getattr("get_tabular_string")?;
+
+    let tabular1_args = PyTuple::new(py, &[gm1]);
+    let tabular1 = py_get_tabular_func.call1(tabular1_args)?.extract::<String>()?;
+
+    let tabular2_args = PyTuple::new(py, &[gm2]);
+    let tabular2 = py_get_tabular_func.call1(tabular2_args)?.extract::<String>()?;
+
+    if tabular1 != tabular2 {
+        println!("Graph tabular representations differ.");
+        // fs::write("tests/data/gm1_tabular.txt", &tabular1).expect("Failed to write gm1_tabular.txt");
+        // fs::write("tests/data/gm2_tabular.txt", &tabular2).expect("Failed to write gm2_tabular.txt");
+        // println!("--- Tabular for GM1:\n{}\n--- Tabular for GM2:\n{}", tabular1, tabular2);
+        return Ok(false);
+    }
+
+    Ok(true)
+}
+
+fn ensure_python_path(py: Python) {
+    if let Some(site_packages_path) = option_env!("FX_PYBRIDGE_TEST_SITE_PACKAGES") {
+        if !site_packages_path.is_empty() {
+            let sys = py.import("sys").expect("Failed to import sys");
+            let mut path: Vec<String> = sys.getattr("path")
+                .expect("Failed to get sys.path")
+                .extract()
+                .expect("Failed to extract sys.path as Vec<String>");
+
+            if !path.iter().any(|p| p == site_packages_path) {
+                // println!(">>> Adding to sys.path via build.rs: {}", site_packages_path);
+                path.insert(0, site_packages_path.to_string());
+                sys.setattr("path", path).expect("Failed to set sys.path");
+            }
+        }
+    }
+}
+
+#[test]
+fn test_graphmodule_pickle_roundtrip() {
+    setup_test_data();
+
+    let comparison_success = Python::with_gil(|py| {
+        // Ensure the Python path includes the site-packages directory
+        ensure_python_path(py);
+
+        let gm_orig = graphmodule_from_pickle(py, ORIG_PICKLE)
+            .expect("Failed to load GraphModule from ORIG_PICKLE");
+
+        graphmodule_to_pickle(py, gm_orig.as_ref(py), ROUNDTRIP_PICKLE)
+            .expect("Failed to save GraphModule to ROUNDTRIP_PICKLE");
+
+        let gm_roundtripped = graphmodule_from_pickle(py, ROUNDTRIP_PICKLE)
+            .expect("Failed to load GraphModule from ROUNDTRIP_PICKLE");
+
+        graphmodules_are_semantically_equal(py, gm_orig.as_ref(py), gm_roundtripped.as_ref(py))
+            .expect("Error during GraphModule comparison")
+    });
+
+    assert!(fs::metadata(ORIG_PICKLE).is_ok());
+    assert!(fs::metadata(ROUNDTRIP_PICKLE).is_ok());
+    assert!(comparison_success, "GraphModules differ semantically after roundtrip");
+
+    cleanup_test_data();
+}

--- a/crates/fx-pybridge/tests/graphmodule_pickle.rs
+++ b/crates/fx-pybridge/tests/graphmodule_pickle.rs
@@ -109,6 +109,4 @@ fn test_graphmodule_pickle_roundtrip() {
     assert!(fs::metadata(ORIG_PICKLE).is_ok());
     assert!(fs::metadata(ROUNDTRIP_PICKLE).is_ok());
     assert!(comparison_success, "GraphModules differ semantically after roundtrip");
-
-    cleanup_test_data();
 }

--- a/crates/fx-pybridge/tests/scripts/gen_fx_module.py
+++ b/crates/fx-pybridge/tests/scripts/gen_fx_module.py
@@ -1,0 +1,17 @@
+import torch
+from pathlib import Path
+import torch.nn as nn
+import torch.fx as fx
+
+class MyModule(nn.Module):
+    def forward(self, a, b):
+        x = torch.ops.aten.add.Tensor(a, b)
+        y = torch.ops.aten.neg.default(a)
+        return torch.ops.aten.add.Tensor(x, y)
+
+m = MyModule()
+gm = fx.symbolic_trace(m)
+output_dir = Path(__file__).parent.parent / "data"
+output_dir.mkdir(parents=True, exist_ok=True)
+output_path = output_dir / "test_module.pt"
+torch.save(gm, output_path)


### PR DESCRIPTION
This PR introduces a new test suite for validating the serialization and deserialization of GraphModule objects using pickle. It includes setup and cleanup functions for test data, as well as a comparison function to ensure semantic equality between original and roundtripped GraphModules.